### PR TITLE
fix: restore compatibility with py36

### DIFF
--- a/diff_pdf_visually/diff.py
+++ b/diff_pdf_visually/diff.py
@@ -9,7 +9,6 @@ INFINITY = float("inf")
 
 import os.path, pathlib, subprocess, sys, tempfile, time
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import nullcontext
 from .constants import DEFAULT_THRESHOLD, DEFAULT_VERBOSITY, DEFAULT_DPI
 from .constants import VERB_PRINT_REASON, VERB_PRINT_TMPDIR
 from .constants import VERB_PERPAGE, VERB_PRINT_CMD, VERB_ROUGH_PROGRESS
@@ -111,7 +110,7 @@ def pdfdiff_pages(
 
     Keyword arguments:
 
-    tempdir: if not None, then this should be a pathlib.Path for an empty writable
+    tempdir: if not None, then this should be a str or a pathlib.Path for an empty writable
         directory where we will put temporary files, which help the user understand
         where differences are and what led to the conclusion on whether the two
         PDF files are significantly different.
@@ -129,18 +128,16 @@ def pdfdiff_pages(
     assert os.path.isfile(a), "file {} must exist".format(a)
     assert os.path.isfile(b), "file {} must exist".format(b)
 
-    if tempdir == None:
+    if tempdir is None:
         path_context = tempfile.TemporaryDirectory(prefix="diffpdf")
     else:
-        assert isinstance(tempdir, pathlib.Path)
-        assert tempdir.is_dir()
-        assert list(tempdir.glob('*')) == [], "should be empty"
-        path_context = nullcontext(tempdir)
+        path_context = pathlib.Path(tempdir)
+        assert path_context.is_dir()
+        assert list(path_context.glob('*')) == [], "should be empty"
 
     with path_context as p:
-        if not isinstance(p, pathlib.Path):
-            # The TemporaryDirectory context manager returns a string
-            p = pathlib.Path(p)
+        # The TemporaryDirectory context manager returns a string
+        p = pathlib.Path(p)
 
         if verbosity >= VERB_PRINT_TMPDIR:
             print("  Temporary directory: {}".format(p))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,4 @@
+import pytest
 from diff_pdf_visually import pdfdiff, pdfdiff_pages
 from tempfile import TemporaryDirectory
 from pathlib import Path
@@ -18,20 +19,27 @@ def test_examples():
     assert [] == pdfdiff_pages("tests/complex_1.pdf", "tests/complex_2.pdf",
         verbosity=0, threshold=10)
 
-    with TemporaryDirectory(dir=".", prefix="test_temp_") as d:
-        p = Path(d)
+@pytest.mark.parametrize("cast_to_path", [False, True])
+def test_tempdir(cast_to_path):
+    with TemporaryDirectory(dir=".", prefix="test_temp_") as input_dir:
+        if cast_to_path:
+            d = Path(input_dir)
+        else:
+            d = input_dir
 
         assert [2, 1] == pdfdiff_pages(
             "tests/complex_1.pdf",
             "tests/complex_2.pdf",
             verbosity=0,
             threshold=100,
-            tempdir=p,
+            tempdir=d,
         )
+
+        d = Path(d)
 
         for template in [
             'a-{}.png', 'b-{}.png', 'diff-{}.png', 'log-{}.txt'
         ]:
-            assert (p / template.format(1)).is_file()
-            assert (p / template.format(2)).is_file()
-            assert not (p / template.format(3)).exists()
+            assert (d / template.format(1)).is_file()
+            assert (d / template.format(2)).is_file()
+            assert not (d / template.format(3)).exists()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist =
+    py36,
+    py37,
     py38,
     py39,
 


### PR DESCRIPTION
Hi @bgeron 
I tested your last release and py36 was still failing because `nullcontext` is only available for py37+. So I took some time to fix it since we don't actually need `nullcontext` in this case. I tested with py36 and py38 so I guess it is also ok with py37 and py39.